### PR TITLE
Fix: LoRA checkpoint path consistency when --output is an absolute path

### DIFF
--- a/Apps/DrawThingsCLI/DrawThingsCLI.swift
+++ b/Apps/DrawThingsCLI/DrawThingsCLI.swift
@@ -3071,6 +3071,7 @@ private func runLoRATraining(_ options: LoRATrainCommandOptions) throws {
   }
 
   let output = options.output.output ?? config.name ?? "lora_output"
+  let resolvedOutputPrefix = URL(fileURLWithPath: output).lastPathComponent
   let name = options.output.name ?? config.name ?? output
   let trainingSteps = options.training.steps ?? Int(config.trainingSteps)
   guard trainingSteps > 0 else { throw ValidationError("--steps must be > 0") }
@@ -3320,7 +3321,7 @@ private func runLoRATraining(_ options: LoRATrainCommandOptions) throws {
       let shouldSave =
         step == trainingSteps || (saveEvery > 0 && step > 0 && step % saveEvery == 0)
       if shouldSave {
-        let filename = "\(output)_\(step)_lora_f32.ckpt"
+        let filename = "\(resolvedOutputPrefix)_\(step)_lora_f32.ckpt"
         let outputPath = LoRAZoo.filePathForModelDownloaded(filename)
         checkpoint.makeLoRA(to: outputPath, scale: loraScale)
         let specification = LoRAZoo.Specification(
@@ -3332,7 +3333,7 @@ private func runLoRATraining(_ options: LoRATrainCommandOptions) throws {
             LoRAZoo.appendCustomSpecification(specification)
           }
         }
-        print("[LoRA] Saved checkpoint: \(filename)")
+        print("[LoRA] Saved checkpoint: \(outputPath)")
       }
     }
     fflush(stdout)
@@ -3341,7 +3342,8 @@ private func runLoRATraining(_ options: LoRATrainCommandOptions) throws {
 
   let totalTime = Date().timeIntervalSince(startTime)
   print("Training complete in \(String(format: "%.1f", totalTime))s.")
-  print("Final checkpoint: \(output)_\(lastStep)_lora_f32.ckpt")
+  let finalFilename = "\(resolvedOutputPrefix)_\(lastStep)_lora_f32.ckpt"
+  print("Final checkpoint: \(LoRAZoo.filePathForModelDownloaded(finalFilename))")
 }
 
 @main


### PR DESCRIPTION
## Problem

When `draw-things-cli train lora` is called with `--output` set to an absolute path (e.g. `--output /tmp/my-lora`), several things go wrong:

1. The checkpoint file name includes the full path prefix (e.g. `/tmp/my-lora_500_lora_f32.ckpt`), which gets routed through `LoRAZoo.filePathForModelDownloaded()` — producing a mangled save path or silent failure.
2. The `custom_lora.json` registry stores the full absolute path as the `file` reference, rather than just the filename. This means the Draw Things app cannot resolve the LoRA when looking it up through the model zoo.
3. The success message prints the raw filename, not the actual path the checkpoint was saved to, misleading users about where to find their LoRA.

## Changes

1. **`resolvedOutputPrefix`** — Extracted via `URL(fileURLWithPath: output).lastPathComponent`, so `/tmp/my-lora` becomes `my-lora`. Used consistently for all checkpoint naming.

2. **Checkpoint save** — Uses `resolvedOutputPrefix` so the save always goes to a clean basename like `my-lora_500_lora_f32.ckpt` inside the model zoo directory.

3. **Print messages** — Now show the actual resolved `outputPath` from `LoRAZoo.filePathForModelDownloaded()`, so users see the real filesystem path.

4. **Final summary** — Updated to use the resolved path consistently.

## Related

Closes #88.