### PR TITLE
Fix SIGABRT on video tensors >= 2^31 elements; honor user fps in CLI export

### DIFF
--- a/Apps/DrawThingsCLI/DrawThingsCLI.swift
+++ b/Apps/DrawThingsCLI/DrawThingsCLI.swift
@@ -99,6 +99,11 @@ private struct ResolvedGenerationConfiguration {
   let configuration: GenerationConfiguration
   let recommendedNegativePrompt: String?
   let loraOverrideMapping: [String: LoRAZoo.Specification]
+  // fps from the user's --config-json / --config-file, when explicitly provided. The
+  // fpsId field on GenerationConfiguration defaults to 5 and is not populated by
+  // recommended settings, so it cannot be used to tell "user asked for this rate"
+  // apart from "unset"; the export path needs that distinction.
+  let userSpecifiedFramesPerSecond: Double?
 }
 
 private enum NetworkAccessPolicy {
@@ -726,9 +731,11 @@ private enum ConfigurationLoader {
         modelsDirectory: modelsDirectory, allowNetwork: !NetworkAccessPolicy.offline)
     let configuration = try mergeOverrides(
       overrideDictionary, onto: recommendedConfiguration, forcingModel: modelSpecification.file)
+    let userSpecifiedFramesPerSecond = (overrideDictionary?["fps"] as? NSNumber)?.doubleValue
     return ResolvedGenerationConfiguration(
       configuration: configuration, recommendedNegativePrompt: recommendedNegativePrompt,
-      loraOverrideMapping: loraOverrideMapping)
+      loraOverrideMapping: loraOverrideMapping,
+      userSpecifiedFramesPerSecond: userSpecifiedFramesPerSecond)
   }
 
   private static func loadOverrideDictionary(
@@ -1767,6 +1774,7 @@ private final class LocalGenerationRunner {
     prompt: String, negativePrompt: String, configuration: GenerationConfiguration,
     outputPath: String,
     inputImage: Tensor<FloatType>?, videoFormat: VideoExportFormat?,
+    userSpecifiedFramesPerSecond: Double? = nil,
     livePreviewSession: TerminalImageRenderer.LivePreviewSession? = nil
   ) throws -> GenerationRunResult {
     let trace = ImageGeneratorTrace(fromBridge: true)
@@ -1803,14 +1811,15 @@ private final class LocalGenerationRunner {
     let timing = timingTracker.summary()
     let outputPaths = try saveOutputs(
       images, audio: audio?.first, outputPath: outputPath, configuration: configuration,
-      videoFormat: videoFormat)
+      videoFormat: videoFormat, userSpecifiedFramesPerSecond: userSpecifiedFramesPerSecond)
     progressPrinter.update(progress: 1, label: "Generated", detail: nil)
     return GenerationRunResult(outputPaths: outputPaths, timing: timing)
   }
 
   private func saveOutputs(
     _ tensors: [Tensor<FloatType>], audio: Tensor<Float>?, outputPath: String,
-    configuration: GenerationConfiguration, videoFormat: VideoExportFormat?
+    configuration: GenerationConfiguration, videoFormat: VideoExportFormat?,
+    userSpecifiedFramesPerSecond: Double? = nil
   ) throws -> [String] {
     let destination = try normalizedOutputDestination(outputPath)
     switch destination {
@@ -1824,7 +1833,8 @@ private final class LocalGenerationRunner {
       }
       return outputPaths
     case .video(let outputURL, let containerExtension):
-      let framesPerSecond = ModelZoo.framesPerSecondForModel(configuration.model ?? "")
+      let framesPerSecond =
+        userSpecifiedFramesPerSecond ?? ModelZoo.framesPerSecondForModel(configuration.model ?? "")
       let audioSampleRate = audio.map { _ in
         Double(ModelZoo.audioSampleRateForModel(configuration.model ?? ""))
       }
@@ -3037,7 +3047,8 @@ private func createConfiguration(
   return ResolvedGenerationConfiguration(
     configuration: builder.build(),
     recommendedNegativePrompt: resolvedConfiguration.recommendedNegativePrompt,
-    loraOverrideMapping: resolvedConfiguration.loraOverrideMapping)
+    loraOverrideMapping: resolvedConfiguration.loraOverrideMapping,
+    userSpecifiedFramesPerSecond: resolvedConfiguration.userSpecifiedFramesPerSecond)
 }
 
 private func runLoRATraining(_ options: LoRATrainCommandOptions) throws {
@@ -3455,7 +3466,9 @@ extension DrawThingsCLI {
       let result = try runner.generate(
         prompt: promptValues.prompt, negativePrompt: resolvedNegativePrompt,
         configuration: configuration, outputPath: outputPath, inputImage: inputImageTensor,
-        videoFormat: output.videoFormat, livePreviewSession: livePreviewSession)
+        videoFormat: output.videoFormat,
+        userSpecifiedFramesPerSecond: resolvedConfiguration.userSpecifiedFramesPerSecond,
+        livePreviewSession: livePreviewSession)
       let renderedFinalImageInPlace =
         livePreviewSession.flatMap { session in
           result.outputPaths.first.flatMap { path in

--- a/Libraries/SwiftDiffusion/Sources/FirstStage.swift
+++ b/Libraries/SwiftDiffusion/Sources/FirstStage.swift
@@ -1736,11 +1736,22 @@ extension FirstStage {
       if existingEncoder == nil {
         encoder.maxConcurrency = .limit(4)
         if highPrecision {
-          encoder.compile(
-            inputs:
-              DynamicGraph.Tensor<Float>(
-                from: x[0..<batchSize, 0..<(startHeight * 32), 0..<(startWidth * 32), 0..<shape[3]])
-          )
+          if shape[0] * shape[1] * shape[2] * shape[3] >= Int(Int32.max) {
+            // Slicing plus datatype-converting a tensor with >= 2^31 total elements trips
+            // 32-bit bounds in ccv view / MPS shape handling. compile() only consumes
+            // shapes, so hand it a correctly-shaped placeholder instead of a real slice.
+            encoder.compile(
+              inputs: graph.variable(
+                .GPU(0), .NHWC(batchSize, startHeight * 32, startWidth * 32, shape[3]),
+                of: Float.self))
+          } else {
+            encoder.compile(
+              inputs:
+                DynamicGraph.Tensor<Float>(
+                  from: x[
+                    0..<batchSize, 0..<(startHeight * 32), 0..<(startWidth * 32), 0..<shape[3]])
+            )
+          }
         } else {
           encoder.compile(
             inputs: x[0..<batchSize, 0..<(startHeight * 32), 0..<(startWidth * 32), 0..<shape[3]])
@@ -1865,10 +1876,20 @@ extension FirstStage {
     else {
       if highPrecision {
         if tiledEncoding {
+          let highPrecisionInput: DynamicGraph.Tensor<Float>
+          if shape[0] * shape[1] * shape[2] * shape[3] >= Int(Int32.max) {
+            // A GPU datatype conversion of a tensor with >= 2^31 total elements trips
+            // 32-bit bounds in ccv view / MPS shape handling. Convert through CPU
+            // memory instead (the CPU kernel is size_t-clean for contiguous tensors);
+            // tiledEncode stages tile extraction through CPU for such tensors anyway.
+            highPrecisionInput = graph.variable(Tensor<Float>(from: x.rawValue.toCPU()))
+          } else {
+            highPrecisionInput = DynamicGraph.Tensor<Float>(from: x)
+          }
           return (
             DynamicGraph.Tensor<FloatType>(
               from: tiledEncode(
-                DynamicGraph.Tensor<Float>(from: x), causalAttentionMask: causalAttentionMask,
+                highPrecisionInput, causalAttentionMask: causalAttentionMask,
                 encoder: encoder,
                 tileSize: encodingTileSize,
                 tileOverlap: encodingTileOverlap,
@@ -2299,6 +2320,14 @@ extension FirstStage {
       return graph.variable(
         Tensor<T>(.GPU(0), .NHWC(resultBatchSize, startHeight, startWidth, outputChannels)))
     }
+    // MPS cannot represent a tensor whose flattened element count exceeds INT_MAX, so any
+    // GPU slice op that views a sufficiently large video tensor trips the MPSNDArray
+    // assertion (e.g. 601 frames at 1920x1088x3 is ~3.8B elements). Stage the source
+    // through CPU memory in that case and extract tiles with 64-bit arithmetic; the
+    // individual tiles are small enough for the regular GPU path.
+    let totalElements = shape[0] * shape[1] * shape[2] * shape[3]
+    let stagedCPUSource: Tensor<T>? =
+      totalElements >= Int(Int32.max) ? z.rawValue.toCPU() : nil
     for y in 0..<yTiles {
       let yOfs = y * (tileSize.height - tileOverlap * 2) + (y > 0 ? tileOverlap : 0)
       let (inputStartYPad, inputEndYPad) = paddedTileStartAndEnd(
@@ -2311,12 +2340,43 @@ extension FirstStage {
           iOfs: xOfs * scaleFactor.spatial, length: shape[2],
           tileSize: tileSize.width * scaleFactor.spatial,
           tileOverlap: tileOverlap * scaleFactor.spatial)
+        let tile: DynamicGraph.Tensor<T>
+        if let stagedCPUSource = stagedCPUSource {
+          let tileHeight = inputEndYPad - inputStartYPad
+          let tileWidth = inputEndXPad - inputStartXPad
+          var tileTensor = Tensor<T>(.CPU, .NHWC(batchSize, tileHeight, tileWidth, channels))
+          stagedCPUSource.withUnsafeBytes {
+            guard let source = $0.baseAddress?.assumingMemoryBound(to: T.self) else { return }
+            tileTensor.withUnsafeMutableBytes {
+              guard let destination = $0.baseAddress?.assumingMemoryBound(to: T.self) else {
+                return
+              }
+              let sourceRowStride = shape[2] * channels
+              let sourceFrameStride = shape[1] * sourceRowStride
+              let rowElements = tileWidth * channels
+              for t in 0..<batchSize {
+                let sourceFrame = source + t * sourceFrameStride
+                let destinationFrame = destination + t * tileHeight * rowElements
+                for row in 0..<tileHeight {
+                  let sourceRow =
+                    sourceFrame + (inputStartYPad + row) * sourceRowStride
+                    + inputStartXPad * channels
+                  destinationFrame.advanced(by: row * rowElements)
+                    .update(from: sourceRow, count: rowElements)
+                }
+              }
+            }
+          }
+          tile = graph.variable(tileTensor.toGPU(0))
+        } else {
+          tile = z[
+            0..<batchSize, inputStartYPad..<inputEndYPad, inputStartXPad..<inputEndXPad,
+            0..<channels
+          ].copied()
+        }
         encodedRawValues.append(
-          encoder(
-            inputs: z[
-              0..<batchSize, inputStartYPad..<inputEndYPad, inputStartXPad..<inputEndXPad,
-              0..<channels
-            ].copied(), (causalAttentionMask.map { [$0] } ?? []))[0].as(of: T.self).rawValue
+          encoder(inputs: tile, (causalAttentionMask.map { [$0] } ?? []))[0].as(of: T.self)
+            .rawValue
             .toCPU())
         guard !isCancelled.load(ordering: .acquiring) else {
           return graph.variable(

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "ccv",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/liuliu/ccv.git",
-      "state" : {
-        "revision" : "48ec1fd002f4da916323fcd8bb79d3e00885dd4f"
-      }
-    },
-    {
       "identity" : "dflat",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/liuliu/dflat.git",
@@ -38,7 +30,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/liuliu/s4nnc.git",
       "state" : {
-        "revision" : "594050126b5cee0dd18488dc05a57947df912878"
+        "revision" : "3219ef1e93aba4744d3b26222b110cd8d83eed8f"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      url: "https://github.com/liuliu/ccv.git", revision: "48ec1fd002f4da916323fcd8bb79d3e00885dd4f"
+      url: "https://github.com/liuliu/ccv.git", revision: "dee5a74ecd2a4c89a06318ae88a4e78d84657225"
     ),
     .package(
       url: "https://github.com/liuliu/s4nnc.git",
-      revision: "594050126b5cee0dd18488dc05a57947df912878"),
+      revision: "3219ef1e93aba4744d3b26222b110cd8d83eed8f"),
     .package(
       url: "https://github.com/liuliu/dflat.git",
       revision: "73925e51e4f44add842177a229f9990cb13711ff"),


### PR DESCRIPTION
## Summary

Long high-resolution video generation aborts (SIGABRT) on macOS once the pixel tensor reaches 2^31 elements — e.g. LTX-2.3 at 1920x1088 with 601 frames (601 × 1088 × 1920 × 3 = 3.77G elements), which is inside the model's envelope (~20 s at 30 fps) but was impossible to generate. This PR fixes the crash chain plus an unrelated fps export bug in `draw-things-cli`, found along the way.

## Repro

```
draw-things-cli generate --model ltx_2.3_22b_distilled_1.1_i8x.ckpt \
  --prompt "..." --width 1920 --height 1088 --frames 601 --seed 7
```

Deterministic abort on v1.20260430.0 and current main (M5 Max, 128 GB, macOS 26). Empirical threshold across 8 runs: crashes iff `frames × height × width × 3 >= 2^31` (1216×704×601f = 1.54G works; 1920×1088×601f = 3.77G and 3840×2176×601f = 15.0G crash). `tiledDecoding`/`tiledDiffusion` don't help — the failing ops precede/ignore spatial tiling.

## Root cause chain (each layer unreachable until the previous one is fixed)

1. **`FirstStage.tiledEncode`** (stage-2 VAE encode) slices spatial tiles out of the full GPU-resident video tensor; `MPSGraphTensorData` asserts on any view of a buffer whose flattened element count exceeds INT_MAX (`MPSNDArray ... dimension length > INT_MAX`, MPSNDArray.mm:831).
2. With (1) fixed, the fp16 encode of 601 frames completes but produces **NaN** (fp16 range accumulation over long causal sequences), engaging the `highPrecisionFallback` — which was previously unreachable at these sizes.
3. The fallback's **encoder compile input** (`DynamicGraph.Tensor<Float>(from: x[full-tensor slice])`) and its **full-tensor fp16→fp32 conversion** both trip the same 32-bit bounds (ccv tensor view assert).
4. The CPU-routed conversion then hits an `int tensor_count` overflow inside ccv's fp16→fp32 kernel — fixed upstream in liuliu/ccv#279 (companion PR, required for the fallback path to work end-to-end).

## Changes

- **`FirstStage.swift`**: when the source video tensor has >= 2^31 elements, stage it through CPU memory once and extract encode tiles with 64-bit pointer arithmetic (same `withUnsafeBytes` idiom as the existing tile blending), uploading only the small tiles to the GPU; compile the high-precision encoder from a shape-only placeholder; run the fallback's fp16→fp32 conversion on the CPU-staged copy. Tensors below the threshold keep the existing GPU path bit-for-bit.
- **`DrawThingsCLI.swift`**: the video export always used `ModelZoo.framesPerSecondForModel`, ignoring a user-provided `fps` (which does reach sampling conditioning). Since `fpsId`'s schema default (5) is indistinguishable from "unset", the explicitly provided `fps` from the `--config-json`/`--config-file` override dictionary is threaded through to `saveOutputs`, with the ModelZoo fallback preserved.
- **`Package.swift`/`Package.resolved`** (separate commit, drop if unwanted): main currently doesn't build with SwiftPM — `SwiftLLM` needs newer s4nnc APIs (`GatedDelta stateCheckpointCount`, `ScaledDotProductArgPartition`) than the pinned revision. Bumped s4nnc to HEAD and ccv to the exact revision s4nnc pins.

## Verification

- The repro above now completes single-pass: 1920×1088, 601 frames, HEVC, 30 fps container, ~85 min on an M5 Max (fp16 encode → NaN → staged fp32 re-encode; the long runtime is the double encode — a config to skip straight to fp32 for long videos would halve it, happy to add if you want it).
- fps fix verified independently: `--config-json '{"fps": 30}'` yields a 30 fps container (49-frame test and the full 601-frame run).
- Short generations (below threshold) unchanged: median step times and outputs match the stock binary.
- Known remaining wrinkle (pre-existing, not addressed here): generated audio length follows the model-native frame pacing, so a 30 fps override yields ~24 s of audio for 20 s of video.

Opening as a draft since this crosses subsystems you know far better — very open to reshaping (e.g. temporal chunked encode with causal state instead of CPU staging, or gating the fallback differently). Crash reports, full repro matrix, and timing data available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
