### PR TITLE
Fix SwiftPM s4nnc dependency pins

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/liuliu/ccv.git",
       "state" : {
-        "revision" : "48ec1fd002f4da916323fcd8bb79d3e00885dd4f"
+        "revision" : "dee5a74ecd2a4c89a06318ae88a4e78d84657225"
       }
     },
     {
@@ -38,7 +38,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/liuliu/s4nnc.git",
       "state" : {
-        "revision" : "594050126b5cee0dd18488dc05a57947df912878"
+        "revision" : "3219ef1e93aba4744d3b26222b110cd8d83eed8f"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      url: "https://github.com/liuliu/ccv.git", revision: "48ec1fd002f4da916323fcd8bb79d3e00885dd4f"
+      url: "https://github.com/liuliu/ccv.git", revision: "dee5a74ecd2a4c89a06318ae88a4e78d84657225"
     ),
     .package(
       url: "https://github.com/liuliu/s4nnc.git",
-      revision: "594050126b5cee0dd18488dc05a57947df912878"),
+      revision: "3219ef1e93aba4744d3b26222b110cd8d83eed8f"),
     .package(
       url: "https://github.com/liuliu/dflat.git",
       revision: "73925e51e4f44add842177a229f9990cb13711ff"),

--- a/WORKSPACE.darwin
+++ b/WORKSPACE.darwin
@@ -79,9 +79,9 @@ dflat_deps()
 
 git_repository(
     name = "s4nnc",
-    commit = "594050126b5cee0dd18488dc05a57947df912878",
+    commit = "3219ef1e93aba4744d3b26222b110cd8d83eed8f",
     remote = "https://github.com/liuliu/s4nnc.git",
-    shallow_since = "1778268631 -0400",
+    shallow_since = "1781311332 -0400",
 )
 
 load("@s4nnc//:deps.bzl", "s4nnc_deps")

--- a/WORKSPACE.linux
+++ b/WORKSPACE.linux
@@ -76,9 +76,9 @@ dflat_deps()
 
 git_repository(
     name = "s4nnc",
-    commit = "594050126b5cee0dd18488dc05a57947df912878",
+    commit = "3219ef1e93aba4744d3b26222b110cd8d83eed8f",
     remote = "https://github.com/liuliu/s4nnc.git",
-    shallow_since = "1778268631 -0400",
+    shallow_since = "1781311332 -0400",
 )
 
 load("@s4nnc//:deps.bzl", "s4nnc_deps")


### PR DESCRIPTION
## Summary

Fixes SwiftPM builds for `gRPCServerCLI` and `draw-things-cli` by syncing the pinned `s4nnc` revision with the newer SwiftLLM APIs now used by `DeepSeek4.swift` and `Qwen3_5.swift`.

The newer `s4nnc` revision requires the matching `ccv` revision, so the direct SwiftPM `ccv` pin is updated as well.

Fixes #98.

## Changes

- Update `s4nnc` from `594050126b5cee0dd18488dc05a57947df912878` to `3219ef1e93aba4744d3b26222b110cd8d83eed8f`.
- Update SwiftPM `ccv` from `48ec1fd002f4da916323fcd8bb79d3e00885dd4f` to `dee5a74ecd2a4c89a06318ae88a4e78d84657225`.
- Keep Bazel workspace `s4nnc` pins in sync with SwiftPM.

## Verification

```sh
swift build --target gRPCServerCLI
swift build --target DrawThingsCLI
swift build --product gRPCServerCLI
swift build --product draw-things-cli
```